### PR TITLE
Prefer PR which has HEAD on requested commit

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ async function main() {
 
     const pullRequests = result.data.filter((pullRequest) => pullRequest.state === 'open' || !filterOutClosed);
 
-    let pr = pullRequests[0] ?? [];
+    let pr = pullRequests.length > 0 && pullRequests[0];
     pullRequests.forEach(pullRequest => pullRequest.head.sha.startsWith(sha) && (pr = pullRequest));
 
     setOutput('number', pr && pr.number.toString() || '');


### PR DESCRIPTION
Sometimes, there are multiple PRs associated with a certain commit.

When this happens, PR with head.sha starting with the requested commit sha should be returned.
