### PR TITLE
Match Branch when checking for PR

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ See [action.yml](action.yml) for more details.
           filterOutClosed: true
           # Only return if PR is not in draft state. (By default it returns PRs in any state.)
           filterOutDraft: true
+          # Only return if PR is on same branch as the job is being run on
+          matchBranch: true
 ```
 
 ### Outputs


### PR DESCRIPTION
## Proposed changes
Fixes #8

This PR would introduce changes to match the underlying PR the job is running on and the found PRs.
This way, a single commit that would be pushed to two different branches would create two different outputs of this job, depending on if each branch had a PR and not if a PR was existent globally no matter on which branch.

## Types of changes

What types of changes does your code introduce ?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

It is yet to nail down, if this should create a breaking change and a full version upgrade to v3 since this behaviour makes sense as a new default behaviour.

Or, if for now we introduce this as a non breaking change and keep the default behaviour of not matching the branch and then exposing a new input variable, possibly named `matchBranch`, that enables this behaviour for the extra special use cases. 